### PR TITLE
비밀번호 수정 기능, 회원 탈퇴 기능

### DIFF
--- a/src/main/java/com/zerobase/challengeproject/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/challengeproject/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
   ALREADY_VERIFY_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 메일입니다."),
   EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
   CONFIRM_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "확인 비밀번호가 일치하지 않습니다."),
+  MATCHES_PREVIOUS_PASSWORD(HttpStatus.BAD_REQUEST,"이전 비밀번호와 동일합니다." ),
 
   INCORRECT_PASSWORD(HttpStatus.BAD_REQUEST,"비밀번호가 틀렸습니다."),
   TOKEN_IS_EXPIRATION(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),

--- a/src/main/java/com/zerobase/challengeproject/member/contoller/MemberController.java
+++ b/src/main/java/com/zerobase/challengeproject/member/contoller/MemberController.java
@@ -35,6 +35,13 @@ public class MemberController {
                         ));
     }
 
+    /**
+     * 회원 정보를 수정하는 컨트롤러 메서드
+     *
+     * @param form 수정 정보 form(nickname, phoneNum)
+     * @param userDetails 로그인한 유저의 정보
+     * @return 수정한 유저의 정보
+     */
     @PatchMapping("/profile")
     public ResponseEntity<BaseResponseDto<MemberProfileDto>> updateProfile (
             @RequestBody MemberProfileFrom form,
@@ -49,6 +56,12 @@ public class MemberController {
         );
     }
 
+    /**
+     * 유저의 비밀번호를 수정하는 메서드
+     * @param form 현재비밀번호, 새비밀번호, 새비밀번호확인
+     * @param userDetails 로그인한 유저의 정보
+     * @return 수정 성공한 유저의 아이디
+     */
     @PatchMapping("/change-password")
     public ResponseEntity<BaseResponseDto<String>> changePassword (
             @RequestBody ChangePasswordForm form,

--- a/src/main/java/com/zerobase/challengeproject/member/contoller/MemberController.java
+++ b/src/main/java/com/zerobase/challengeproject/member/contoller/MemberController.java
@@ -3,6 +3,7 @@ package com.zerobase.challengeproject.member.contoller;
 import com.zerobase.challengeproject.BaseResponseDto;
 import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberProfileDto;
+import com.zerobase.challengeproject.member.domain.form.ChangePasswordForm;
 import com.zerobase.challengeproject.member.domain.form.MemberProfileFrom;
 import com.zerobase.challengeproject.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +35,7 @@ public class MemberController {
                         ));
     }
 
-    @PatchMapping("profile")
+    @PatchMapping("/profile")
     public ResponseEntity<BaseResponseDto<MemberProfileDto>> updateProfile (
             @RequestBody MemberProfileFrom form,
             @AuthenticationPrincipal UserDetailsImpl userDetails
@@ -43,6 +44,20 @@ public class MemberController {
                 new BaseResponseDto<>(
                         memberService.updateProfile(userDetails, form),
                         "회원 정보 수정 성공했습니다",
+                        HttpStatus.OK
+                )
+        );
+    }
+
+    @PatchMapping("/change-password")
+    public ResponseEntity<BaseResponseDto<String>> changePassword (
+            @RequestBody ChangePasswordForm form,
+            @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return ResponseEntity.ok(
+                new BaseResponseDto<>(
+                        memberService.changePassword(userDetails, form),
+                        "비밀 번호 수정 성공했습니다",
                         HttpStatus.OK
                 )
         );

--- a/src/main/java/com/zerobase/challengeproject/member/contoller/MemberSignupController.java
+++ b/src/main/java/com/zerobase/challengeproject/member/contoller/MemberSignupController.java
@@ -1,14 +1,18 @@
 package com.zerobase.challengeproject.member.contoller;
 
 import com.zerobase.challengeproject.BaseResponseDto;
+import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberEmailAuthDto;
 import com.zerobase.challengeproject.member.domain.dto.MemberSignupDto;
 import com.zerobase.challengeproject.member.domain.form.MemberSignupForm;
 import com.zerobase.challengeproject.member.service.MemberSignupService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -36,5 +40,13 @@ public class MemberSignupController {
     @GetMapping("/email-auth")
     public ResponseEntity<BaseResponseDto<MemberEmailAuthDto>> verifyEmail(@RequestParam("id") String emailAuthKey){
         return ResponseEntity.ok(new BaseResponseDto<>(memberService.verifyEmail(emailAuthKey),"이메일 인증 완료되었습니다.", HttpStatus.OK));
+    }
+
+    @DeleteMapping("/unregister")
+    public ResponseEntity<BaseResponseDto> unregister(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ResponseCookie cookie = memberService.unregister(userDetails);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE,cookie.toString())
+                .body(new BaseResponseDto<>(null,"회원 탈퇴 성공했습니다.", HttpStatus.OK));
     }
 }

--- a/src/main/java/com/zerobase/challengeproject/member/contoller/MemberSignupController.java
+++ b/src/main/java/com/zerobase/challengeproject/member/contoller/MemberSignupController.java
@@ -42,6 +42,11 @@ public class MemberSignupController {
         return ResponseEntity.ok(new BaseResponseDto<>(memberService.verifyEmail(emailAuthKey),"이메일 인증 완료되었습니다.", HttpStatus.OK));
     }
 
+    /**
+     * 회원 탈퇴 요청시 사용되는 컨트롤러 메서드
+     * @param userDetails 로그인한 유저의 정보
+     * @return 아무 정보도 없는 쿠키, 회원 탈퇴 성공 메세지
+     */
     @DeleteMapping("/unregister")
     public ResponseEntity<BaseResponseDto> unregister(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         ResponseCookie cookie = memberService.unregister(userDetails);

--- a/src/main/java/com/zerobase/challengeproject/member/domain/form/ChangePasswordForm.java
+++ b/src/main/java/com/zerobase/challengeproject/member/domain/form/ChangePasswordForm.java
@@ -1,0 +1,25 @@
+package com.zerobase.challengeproject.member.domain.form;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChangePasswordForm {
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$",
+            message = "비밀번호는 8 ~ 15자이며, 최소 하나의 영문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String password;
+    @NotBlank
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,15}$",
+            message = "비밀번호는 8 ~ 15자이며, 최소 하나의 영문자, 숫자, 특수 문자를 포함해야 합니다."
+    )
+    private String newPassword;
+    @NotBlank
+    private String newPasswordVerify;
+}

--- a/src/main/java/com/zerobase/challengeproject/member/entity/Member.java
+++ b/src/main/java/com/zerobase/challengeproject/member/entity/Member.java
@@ -103,4 +103,8 @@ public class Member {
         refund.refundTrue();
         this.account -= detail.getAmount();
     }
+
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
+    }
 }

--- a/src/main/java/com/zerobase/challengeproject/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/challengeproject/member/service/MemberService.java
@@ -30,6 +30,12 @@ public class MemberService {
         return new MemberProfileDto(member);
     }
 
+    /**
+     * 유저의 정보를 수정할 떄 사용되는 서비스 메서드
+     * @param userDetails 로그인한 유저의 정보
+     * @param form 수정 정보 form(nickname, phoneNum)
+     * @return 수정한 유저의 정보
+     */
     @Transactional
     public MemberProfileDto updateProfile(UserDetailsImpl userDetails, MemberProfileFrom form) {
         Member member = findMemberByMemberId(userDetails.getUsername());
@@ -37,6 +43,16 @@ public class MemberService {
         return new MemberProfileDto(member);
     }
 
+    /**
+     * 유저의 비밀번호를 변경시 사용되는 서비스 메서드
+     * 유저가 입력한 비밀번호가 테이블에 저장된 비밀번호가 다를 시 예외 발생
+     * 새비밀번호와 새 비밀번호 확인이 다를시 예외 발생
+     * 새 비밀번호와 테이블에 저장된 비밀번호가 같을 시 예외발생
+     *
+     * @param userDetails 로그인한 유저의 정보
+     * @param form 비밀번호, 새비밀번호, 새비밀번호확인
+     * @return 비밀번호를 변경한 유저의 아이디
+     */
     @Transactional
     public String changePassword(UserDetailsImpl userDetails, ChangePasswordForm form) {
         Member member = findMemberByMemberId(userDetails.getUsername());
@@ -54,7 +70,11 @@ public class MemberService {
         return member.getMemberId();
     }
 
-
+    /**
+     * userDetails에 있는 유저의 정보로 DB에서 유저 객체를 가져오고 없으면 예외 발생
+     * @param memberId 유저의 로그인 아이디
+     * @return 유저 객체
+     */
     private Member findMemberByMemberId(String memberId) {
         return memberRepository.findByMemberId(memberId)
                 .orElseThrow(()-> new CustomException(ErrorCode.NOT_FOUND_MEMBER));

--- a/src/main/java/com/zerobase/challengeproject/member/service/MemberService.java
+++ b/src/main/java/com/zerobase/challengeproject/member/service/MemberService.java
@@ -2,13 +2,14 @@ package com.zerobase.challengeproject.member.service;
 
 import com.zerobase.challengeproject.exception.CustomException;
 import com.zerobase.challengeproject.exception.ErrorCode;
-import com.zerobase.challengeproject.member.components.MailComponents;
 import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberProfileDto;
+import com.zerobase.challengeproject.member.domain.form.ChangePasswordForm;
 import com.zerobase.challengeproject.member.domain.form.MemberProfileFrom;
 import com.zerobase.challengeproject.member.entity.Member;
 import com.zerobase.challengeproject.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,9 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
-    private final MailComponents mailComponents;
-    private String domainAddress = "localhost:8080";
 
     /**
      * 유저가 회원 정보를 조회할 때 사용되는 서비스 메서드
@@ -35,6 +35,23 @@ public class MemberService {
         Member member = findMemberByMemberId(userDetails.getUsername());
         member.updateProfile(form.getPhoneNum(),form.getNickname());
         return new MemberProfileDto(member);
+    }
+
+    @Transactional
+    public String changePassword(UserDetailsImpl userDetails, ChangePasswordForm form) {
+        Member member = findMemberByMemberId(userDetails.getUsername());
+        if(!passwordEncoder.matches(form.getPassword(), member.getPassword())) {
+            throw new CustomException(ErrorCode.INCORRECT_PASSWORD);
+        }
+        if(!form.getNewPassword().equals(form.getNewPasswordVerify())) {
+            throw new CustomException(ErrorCode.INCORRECT_PASSWORD);
+        }
+        if(passwordEncoder.matches(form.getNewPassword(), member.getPassword())) {
+            throw new CustomException(ErrorCode.MATCHES_PREVIOUS_PASSWORD);
+        }
+        String password = passwordEncoder.encode(form.getNewPassword());
+        member.changePassword(password);
+        return member.getMemberId();
     }
 
 

--- a/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
+++ b/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
@@ -98,6 +98,11 @@ public class MemberSignupService {
         return  new MemberEmailAuthDto(member);
     }
 
+    /**
+     * 회원 탈퇴시 사용하는 서비스 메서드
+     * @param userDetails 로그인한 유저의 정보
+     * @return 정보가 없는 쿠키
+     */
     public ResponseCookie unregister(UserDetailsImpl userDetails) {
         Member member = memberRepository.findByMemberId(userDetails.getUsername())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));

--- a/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
+++ b/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
@@ -3,15 +3,19 @@ package com.zerobase.challengeproject.member.service;
 import com.zerobase.challengeproject.exception.CustomException;
 import com.zerobase.challengeproject.exception.ErrorCode;
 import com.zerobase.challengeproject.member.components.MailComponents;
+import com.zerobase.challengeproject.member.components.jwt.JwtUtil;
+import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberEmailAuthDto;
 import com.zerobase.challengeproject.member.domain.dto.MemberSignupDto;
 import com.zerobase.challengeproject.member.domain.form.MemberSignupForm;
 import com.zerobase.challengeproject.member.entity.Member;
 import com.zerobase.challengeproject.member.repository.MemberRepository;
+import com.zerobase.challengeproject.member.repository.RefreshTokenRepository;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +31,8 @@ public class MemberSignupService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final MailComponents mailComponents;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
 
     /**
      * 회원 가입시 사용되는 서비스 메서드, 비밀번호와 확인 비밀번호가 다르면 예외 발생.
@@ -90,5 +96,14 @@ public class MemberSignupService {
 
         member.completeEmailAuth();
         return  new MemberEmailAuthDto(member);
+    }
+
+    public ResponseCookie unregister(UserDetailsImpl userDetails) {
+        Member member = memberRepository.findByMemberId(userDetails.getUsername())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+        refreshTokenRepository.deleteByMemberId(member.getMemberId());
+        ResponseCookie responseCookie =  jwtUtil.createRefreshTokenCookie("", 0);
+        memberRepository.delete(member);
+        return responseCookie;
     }
 }

--- a/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
+++ b/src/main/java/com/zerobase/challengeproject/member/service/MemberSignupService.java
@@ -98,6 +98,13 @@ public class MemberSignupService {
         return  new MemberEmailAuthDto(member);
     }
 
+    /**
+     * 회원 탈퇴시 사용하는 서비스 메서드
+     * 유저 탈퇴시 가지고 있던 리프레시 토큰 삭제
+     * 아무런 정보도 가지고 있지 않은 쿠키 생성
+     * @param userDetails 로그인한 유저의 정보
+     * @return 정보가 없는 쿠키
+     */
     public ResponseCookie unregister(UserDetailsImpl userDetails) {
         Member member = memberRepository.findByMemberId(userDetails.getUsername())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));

--- a/src/test/java/com/zerobase/challengeproject/member/service/MemberServiceTest.java
+++ b/src/test/java/com/zerobase/challengeproject/member/service/MemberServiceTest.java
@@ -4,6 +4,8 @@ import com.zerobase.challengeproject.exception.CustomException;
 import com.zerobase.challengeproject.exception.ErrorCode;
 import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberProfileDto;
+import com.zerobase.challengeproject.member.domain.form.ChangePasswordForm;
+import com.zerobase.challengeproject.member.domain.form.MemberProfileFrom;
 import com.zerobase.challengeproject.member.entity.Member;
 import com.zerobase.challengeproject.member.repository.MemberRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -12,18 +14,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
     @InjectMocks
     private MemberService memberService;
@@ -69,4 +75,156 @@ class MemberServiceTest {
         assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("프로필 업데이트 성공")
+    void updateProfile() {
+        // given
+        Member member = Member.builder()
+                .memberId("testId")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        MemberProfileFrom form = MemberProfileFrom.builder()
+                .nickname("testNickname")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        when(memberRepository.findByMemberId(userDetails.getUsername())).thenReturn(Optional.of(member));
+        // When
+        MemberProfileDto result = memberService.updateProfile(userDetails, form);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(form.getPhoneNum(), result.getPhoneNum());
+        assertEquals(form.getNickname(), result.getNickName());
+        verify(memberRepository, times(1)).findByMemberId(member.getMemberId());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 성공")
+    void changePassword() {
+        // given
+        Member member = Member.builder()
+                .memberId("testId")
+                .password("testPassword")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        ChangePasswordForm form = ChangePasswordForm.builder()
+                .password("testPassword")
+                .newPassword("newPassword")
+                .newPasswordVerify("newPassword")
+                .build();
+        when(memberRepository.findByMemberId(userDetails.getUsername())).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches("testPassword", member.getPassword())).thenReturn(true);
+        when(passwordEncoder.matches("newPassword", member.getPassword())).thenReturn(false);
+        when(passwordEncoder.encode("newPassword")).thenReturn("newEncodePassword");
+
+        // When
+        String result = memberService.changePassword(userDetails, form);
+
+        // Then
+        assertEquals(member.getMemberId(), result);
+        verify(passwordEncoder, times(1)).matches("testPassword", "testPassword");
+        verify(passwordEncoder, times(1)).matches("newPassword", "testPassword");
+        verify(passwordEncoder, times(1)).encode("newPassword");
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 현재 비밀번호가 일치하지 않는 경우 예외 발생")
+    void changePasswordFailure() {
+        // Given
+        Member member = Member.builder()
+                .memberId("testId")
+                .password("testPassword")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        ChangePasswordForm form = ChangePasswordForm.builder()
+                .password("wrongPassword")
+                .newPassword("newPassword")
+                .newPasswordVerify("newPassword")
+                .build();
+        when(memberRepository.findByMemberId(userDetails.getUsername())).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches(anyString(), eq(member.getPassword())))
+                .thenAnswer(invocation -> {
+                    String rawPassword = invocation.getArgument(0);
+                    return rawPassword.equals("testPassword");
+                });
+        //when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.changePassword(userDetails, form);
+        });
+        assertEquals(ErrorCode.INCORRECT_PASSWORD, exception.getErrorCode());
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 실패 - 새 비밀번호와 확인이 일치하지 않는 경우 예외 발생")
+    void changePasswordFailure2() {
+        // Given
+        Member member = Member.builder()
+                .memberId("testId")
+                .password("testPassword")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        ChangePasswordForm form = ChangePasswordForm.builder()
+                .password("testPassword")
+                .newPassword("newPassword")
+                .newPasswordVerify("wrongNewPassword")
+                .build();
+        when(memberRepository.findByMemberId(userDetails.getUsername())).thenReturn(Optional.of(member));
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.changePassword(userDetails, form);
+        });
+        assertEquals(ErrorCode.INCORRECT_PASSWORD, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 - 새 비밀번호가 기존 비밀번호와 같은 경우 예외 발생")
+    void changePassword_MatchesPreviousPassword() {
+        // Given
+        Member member = Member.builder()
+                .memberId("testId")
+                .password("testPassword")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        ChangePasswordForm form = ChangePasswordForm.builder()
+                .password("testPassword")
+                .newPassword("testPassword")
+                .newPasswordVerify("testPassword")
+                .build();
+        when(memberRepository.findByMemberId(userDetails.getUsername())).thenReturn(Optional.of(member));
+        when(passwordEncoder.matches(form.getPassword(), member.getPassword())).thenReturn(true);
+        when(passwordEncoder.matches(form.getPassword(), member.getPassword())).thenReturn(true);
+
+        // When & Then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.changePassword(userDetails, form);
+        });
+        assertEquals(ErrorCode.MATCHES_PREVIOUS_PASSWORD, exception.getErrorCode());
+        verify(passwordEncoder, never()).encode(any());
+    }
 }

--- a/src/test/java/com/zerobase/challengeproject/member/service/MemberSignupServiceTest.java
+++ b/src/test/java/com/zerobase/challengeproject/member/service/MemberSignupServiceTest.java
@@ -3,17 +3,21 @@ package com.zerobase.challengeproject.member.service;
 import com.zerobase.challengeproject.exception.CustomException;
 import com.zerobase.challengeproject.exception.ErrorCode;
 import com.zerobase.challengeproject.member.components.MailComponents;
+import com.zerobase.challengeproject.member.components.jwt.JwtUtil;
+import com.zerobase.challengeproject.member.components.jwt.UserDetailsImpl;
 import com.zerobase.challengeproject.member.domain.dto.MemberEmailAuthDto;
 import com.zerobase.challengeproject.member.domain.dto.MemberSignupDto;
 import com.zerobase.challengeproject.member.domain.form.MemberSignupForm;
 import com.zerobase.challengeproject.member.entity.Member;
 import com.zerobase.challengeproject.member.repository.MemberRepository;
+import com.zerobase.challengeproject.member.repository.RefreshTokenRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
@@ -32,6 +36,12 @@ class MemberSignupServiceTest {
 
     @Mock
     private MailComponents mailComponents;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
 
     @InjectMocks
     private MemberSignupService memberService;
@@ -136,5 +146,54 @@ class MemberSignupServiceTest {
             memberService.verifyEmail(emailAuthKey);
         });
         assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 - 정상 동작")
+    void unregister_Success() {
+        // given
+        Member member = Member.builder()
+                .memberId("testId")
+                .memberName("testName")
+                .nickname("testNickname")
+                .email("testEmail@email.com")
+                .phoneNum("01011112222")
+                .build();
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(member.getMemberId());
+        ResponseCookie mockCookie = ResponseCookie.from("refreshToken", "")
+                .maxAge(0)
+                .build();
+        when(memberRepository.findByMemberId(member.getMemberId())).thenReturn(Optional.of(member));
+        when(jwtUtil.createRefreshTokenCookie("", 0)).thenReturn(mockCookie);
+
+        // when
+        ResponseCookie responseCookie = memberService.unregister(userDetails);
+
+        // Then
+        assertNotNull(responseCookie);
+        assertEquals("", responseCookie.getValue());
+        assertEquals(0, responseCookie.getMaxAge().getSeconds());
+        verify(refreshTokenRepository, times(1)).deleteByMemberId(member.getMemberId());
+        verify(memberRepository, times(1)).delete(member);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 - 회원이 존재하지 않을 경우 예외 발생")
+    void unregister_MemberNotFound() {
+        //given
+        String memberId = "nonExistentUser";
+        UserDetailsImpl userDetails = mock(UserDetailsImpl.class);
+        when(userDetails.getUsername()).thenReturn(memberId);
+        when(memberRepository.findByMemberId(memberId)).thenReturn(Optional.empty());
+
+        //when & then
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            memberService.unregister(userDetails);
+        });
+
+        assertEquals(ErrorCode.NOT_FOUND_MEMBER, exception.getErrorCode());
+        verify(refreshTokenRepository, never()).deleteByMemberId(any());
+        verify(memberRepository, never()).delete(any());
     }
 }


### PR DESCRIPTION
<!-- #3 feature:mallangc -> 코멘트 기능 -->
## #️⃣ Issue Number
#38 #37 #38 
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)
- 회원 탈퇴시 테이블에 있는 리프레시 토큰을 삭제하고 아무런 정보가 없는 쿠키를 보낸다.
- 비밀번호 변경 시 비밀번호 확인이 필요하고 새 비밀번호와 이전 비밀번호가 같으면 안된다.

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
